### PR TITLE
(myTime: Issue #17) - Correção de bug

### DIFF
--- a/frontend/src/components/home/charts/UserChart.vue
+++ b/frontend/src/components/home/charts/UserChart.vue
@@ -225,7 +225,7 @@ export default {
 
 					res.data.result.forEach((element) => {
 						this.chartSerieName.push(element.name)
-						this.chartBarData.push(minutesToHours(element.minutes))
+						this.chartBarData.push(minutesToHours(element.minutes, false))
 						this.chartDonutData.push(Number.parseFloat(element.minutes))
 						totalHours += Number.parseFloat(element.minutes)
 					});

--- a/frontend/src/components/utils.js
+++ b/frontend/src/components/utils.js
@@ -1,4 +1,4 @@
-export function minutesToHours(totalMinutes) {
+export function minutesToHours(totalMinutes, useFormatting = true) {
     if (totalMinutes) {
         let hours = Math.trunc(totalMinutes / 60)
         let minutes = totalMinutes % 60
@@ -9,8 +9,10 @@ export function minutesToHours(totalMinutes) {
         if (minutes < 10) {
             minutes = `0${minutes}`
         }
-    
-        return formatterTooltip(`${hours}.${minutes}`)
+
+        var hoursWithoutFormatting = `${hours}.${minutes}`
+
+        return useFormatting ? formatterTooltip(hoursWithoutFormatting) : hoursWithoutFormatting
     }
     return "0h00min"
 }


### PR DESCRIPTION
A formatação da hora estava sendo feita duas vezes, e na segunda vez desconsiderava os minutos, exibindo somente a hora na label.